### PR TITLE
[v12] Agregar secuencias MR a res_company

### DIFF
--- a/cr_electronic_invoice/data/sequence.xml
+++ b/cr_electronic_invoice/data/sequence.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
+        <!-- TODO-->
+        <!-- Secuencias de MR para asignar a la primera compañía.  Si hay más compañías, debemos generar las secuencias-->
         <record id="seq_electronic_doc_confirmation" model="ir.sequence">
             <field name="name">Secuencia de Confirmación de Aceptación Comprobante Electrónico</field>
             <field name="code">sequece.electronic.doc.confirmation</field>

--- a/cr_electronic_invoice/models/account_invoice.py
+++ b/cr_electronic_invoice/models/account_invoice.py
@@ -455,18 +455,17 @@ class AccountInvoiceElectronic(models.Model):
                                 detalle_mensaje = 'Aceptado'
                                 tipo = 1
                                 tipo_documento = 'CCE'
-                                sequence = inv.env['ir.sequence'].next_by_code('sequece.electronic.doc.confirmation')
+                                sequence = inv.company_id.CCE_sequence_id.next_by_id()
                             elif inv.state_invoice_partner == '2':
                                 detalle_mensaje = 'Aceptado parcial'
                                 tipo = 2
                                 tipo_documento = 'CPCE'
-                                sequence = inv.env['ir.sequence'].next_by_code(
-                                    'sequece.electronic.doc.partial.confirmation')
+                                sequence = inv.company_id.CPCE_sequence_id.next_by_id()
                             else:
                                 detalle_mensaje = 'Rechazado'
                                 tipo = 3
                                 tipo_documento = 'RCE'
-                                sequence = inv.env['ir.sequence'].next_by_code('sequece.electronic.doc.reject')
+                                sequence = inv.company_id.RCE_sequence_id.next_by_id()
 
                             '''Si el mensaje fue rechazado, necesitamos generar un nuevo id'''
                             if inv.state_send_invoice == 'rechazado' or inv.state_send_invoice == 'error':
@@ -911,7 +910,7 @@ class AccountInvoiceElectronic(models.Model):
                 if False:                     
                     # Firmamos con el api. Por ahora todo lo firmamos con el API CR LIBRE
                     # TODO: cambiar esto para utilizar algun firmador desde Python
-                    response_json = functions.sign_xml(inv, tipo_documento, url, xml)
+                    response_json = api_facturae.sign_xml(inv, tipo_documento, url, xml)
                     # response_json = api_facturae.sign_file2(inv.company_id.signature, inv.company_id.frm_pin, xml)
 
                     # another_test = api_facturae.sign_xml(xml, inv.company_id.signature, inv.company_id.frm_pin)

--- a/cr_electronic_invoice/models/res_company.py
+++ b/cr_electronic_invoice/models/res_company.py
@@ -39,18 +39,11 @@ class CompanyElectronic(models.Model):
     frm_callback_url = fields.Char(string="Callback Url", required=False, default="https://url_callback/repuesta.php?",
                                    help='Es la URL en a la cual se reenviarán las respuestas de Hacienda.')
 
-    # activated = fields.Boolean('Activado')
-    # state = fields.Selection([
-    #    ('draft', 'Draft'),
-    #    ('started', 'Started'),
-    #    ('progress', 'In progress'),
-    #    ('finished', 'Done'),
-    # ], default='draft')
-
-    # frm_apicr_username = fields.Char(string="Usuario de Api", required=False, )
-    # frm_apicr_password = fields.Char(string="Password de Api", required=False, )
     frm_apicr_signaturecode = fields.Char(string="Codigo para Firmar API", required=False, )
 
-    # @api.onchange('email')
-    # def _onchange_email(self):
-    #    pass
+    CCE_sequence_id = fields.Many2one('ir.sequence', string='Secuencia de Confirmación de Aceptación Comprobante Electrónico', 
+                                      readonly=False, copy=False)
+    CPCE_sequence_id = fields.Many2one('ir.sequence', string='Secuencia de Confirmación de Aceptación Parcial Comprobante Electrónico', 
+                                       readonly=False, copy=False)
+    RCE_sequence_id = fields.Many2one('ir.sequence', string='Secuencia de Rechazo Comprobante Electrónico', 
+                                      readonly=False, copy=False)

--- a/cr_electronic_invoice/views/res_company_views.xml
+++ b/cr_electronic_invoice/views/res_company_views.xml
@@ -76,6 +76,11 @@
                                 <field name="frm_apicr_signaturecode"/>
 								<!--<field name="frm_tipo_id"/>-->
 							</group>
+							<group cols="2" >
+								<field name="CCE_sequence_id"/>
+								<field name="CPCE_sequence_id"/>
+								<field name="RCE_sequence_id"/>
+							</group>
 						</group>
 					</page>
 				</xpath>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Con secuencias MR a nivel de res_company, permitimos la recepción de documentos en ambientes multicompañía

Además, se modifica el cálculo de líneas de facturas, para corregir problemas de diferencias de redondeo contra los cálculos de Hacienda

Current behavior before PR:
Los MR no funcionan en ambientes multicompañía

Desired behavior after PR is merged:
Cada compañía tiene sus propias secuencias de MR, por lo que se puede trabajar en ambientes multicompañía