### PR TITLE
ValueError: <class 'TypeError'>: "a bytes-like object is required, not 'str'" while evaluating

### DIFF
--- a/cr_electronic_invoice/models/account_invoice.py
+++ b/cr_electronic_invoice/models/account_invoice.py
@@ -1490,7 +1490,7 @@ class AccountInvoiceElectronic(models.Model):
                 _logger.info('E-INV CR - SIGNED XML:%s',
                              inv.fname_xml_comprobante)
             else:
-                xml_firmado = inv.xml_comprobante.decode("UTF-8")
+                xml_firmado = inv.xml_comprobante
 
             # Obtenemos el token con el api interna
             token_m_h = api_facturae.get_token_hacienda(


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When you try to validate invoices to Hacienda you will receive this message
ValueError: <class 'TypeError'>: "a bytes-like object is required, not 'str'" while evaluating

Current behavior before PR:
You can't send xml to Hacienda
Desired behavior after PR is merged:
You can send xml to Hacienda