### PR TITLE
V12 Eliminar comodel_name= para facilitar backport

### DIFF
--- a/cr_electronic_invoice/models/account_invoice.py
+++ b/cr_electronic_invoice/models/account_invoice.py
@@ -31,9 +31,9 @@ class AccountInvoiceRefund(models.TransientModel):
         return ''
 
     reference_code_id = fields.Many2one(
-        comodel_name="reference.code", string="Código de referencia",
+        "reference.code", string="Código de referencia",
         required=True, )
-    invoice_id = fields.Many2one(comodel_name="account.invoice",
+    invoice_id = fields.Many2one("account.invoice",
                                  string="Documento de referencia",
                                  default=_get_invoice_id, required=False, )
 
@@ -149,7 +149,7 @@ class InvoiceLineElectronic(models.Model):
     discount_note = fields.Char(string="Nota de descuento", required=False, )
     total_tax = fields.Float(string="Total impuesto", required=False, )
 
-    third_party_id = fields.Many2one(comodel_name="res.partner",
+    third_party_id = fields.Many2one("res.partner",
                                      string="Tercero otros cargos",)
 
     tariff_head = fields.Char(string="Partida arancelaria para factura"
@@ -198,14 +198,14 @@ class AccountInvoiceElectronic(models.Model):
         [('1', 'Aceptado'), ('3', 'Rechazado'), ('2', 'Aceptacion parcial')],
         'Respuesta del Cliente')
     reference_code_id = fields.Many2one(
-        comodel_name="reference.code", string="Código de referencia",
+        "reference.code", string="Código de referencia",
         required=False, )
 
     payment_methods_id = fields.Many2one(
-        comodel_name="payment.methods", string="Métodos de Pago",
+        "payment.methods", string="Métodos de Pago",
         required=False, )
 
-    invoice_id = fields.Many2one(comodel_name="account.invoice",
+    invoice_id = fields.Many2one("account.invoice",
                                  string="Documento de referencia",
                                  required=False,
                                  copy=False)

--- a/cr_electronic_invoice/models/account_journal.py
+++ b/cr_electronic_invoice/models/account_journal.py
@@ -12,19 +12,19 @@ class AccountJournalInherit(models.Model):
     sucursal = fields.Integer(string="Sucursal", required=False, default="1")
     terminal = fields.Integer(string="Terminal", required=False, default="1")
 
-    FE_sequence_id = fields.Many2one(comodel_name="ir.sequence",
+    FE_sequence_id = fields.Many2one("ir.sequence",
                                      string="Secuencia de Facturas Electrónicas",
                                      required=False)
-    TE_sequence_id = fields.Many2one(comodel_name="ir.sequence",
+    TE_sequence_id = fields.Many2one("ir.sequence",
                                      string="Secuencia de Tiquetes Electrónicos",
                                      required=False)
-    FEE_sequence_id = fields.Many2one(comodel_name="ir.sequence",
+    FEE_sequence_id = fields.Many2one("ir.sequence",
                                       string="Secuencia de Facturas Electrónicas de Exportación",
                                       required=False)
-    NC_sequence_id = fields.Many2one(comodel_name="ir.sequence",
+    NC_sequence_id = fields.Many2one("ir.sequence",
                                      string="Secuencia de Notas de Crédito Electrónicas",
                                      required=False)
-    ND_sequence_id = fields.Many2one(comodel_name="ir.sequence",
+    ND_sequence_id = fields.Many2one("ir.sequence",
                                      string="Secuencia de Notas de Débito Electrónicas",
                                      required=False)
 

--- a/cr_electronic_invoice/models/account_payment.py
+++ b/cr_electronic_invoice/models/account_payment.py
@@ -14,4 +14,4 @@ class PaymentMethods(models.Model):
 class AccountPaymentTerm(models.Model):
     _inherit = "account.payment.term"
     sale_conditions_id = fields.Many2one(
-        comodel_name="sale.conditions", string="Condiciones de venta")
+        "sale.conditions", string="Condiciones de venta")

--- a/cr_electronic_invoice/models/account_tax.py
+++ b/cr_electronic_invoice/models/account_tax.py
@@ -15,7 +15,7 @@ class IvaCodeType(models.Model):
     has_exoneration = fields.Boolean(string="Impuesto Exonerado", required=False)
     percentage_exoneration = fields.Integer(string="Porcentaje de Exoneracion", required=False)
     tax_root = fields.Many2one(
-        comodel_name="account.tax", string="Impuesto Padre", required=False, )
+        "account.tax", string="Impuesto Padre", required=False, )
 
     @api.onchange('percentage_exoneration')
     def _onchange_percentage_exoneration(self):

--- a/cr_electronic_invoice/models/product_template.py
+++ b/cr_electronic_invoice/models/product_template.py
@@ -16,7 +16,7 @@ class ProductElectronic(models.Model):
 
     commercial_measurement = fields.Char(
         string="Unidad de Medida Comercial", required=False, )
-    code_type_id = fields.Many2one(comodel_name="code.type.product", string="Tipo de código", required=False,
+    code_type_id = fields.Many2one("code.type.product", string="Tipo de código", required=False,
                                    default=_default_code_type_id)
 
     tariff_head = fields.Char(string="Partida arancelaria para factura"

--- a/cr_electronic_invoice/models/res_company.py
+++ b/cr_electronic_invoice/models/res_company.py
@@ -24,18 +24,18 @@ class CompanyElectronic(models.Model):
 
     commercial_name = fields.Char(string="Nombre comercial", required=False, )
 
-    activity_id = fields.Many2one(comodel_name="economic_activity", string="Actividad Económica",
+    activity_id = fields.Many2one("economic_activity", string="Actividad Económica",
                                   required=False, )
 
     signature = fields.Binary(string="Llave Criptográfica", )
     identification_id = fields.Many2one(
-        comodel_name="identification.type", string="Tipo de identificacion", required=False)
-    district_id = fields.Many2one(comodel_name="res.country.district", string="Distrito",
+        "identification.type", string="Tipo de identificacion", required=False)
+    district_id = fields.Many2one("res.country.district", string="Distrito",
                                   required=False)
-    county_id = fields.Many2one(comodel_name="res.country.county", string="Cantón",
+    county_id = fields.Many2one("res.country.county", string="Cantón",
                                 required=False)
-    neighborhood_id = fields.Many2one(comodel_name="res.country.neighborhood", string="Barrios",
-                                      required=False, )
+    neighborhood_id = fields.Many2one("res.country.neighborhood", string="Barrios",
+                                      required=False)
     frm_ws_identificador = fields.Char(
         string="Usuario de Factura Electrónica", required=False)
     frm_ws_password = fields.Char(

--- a/cr_electronic_invoice/models/res_partner.py
+++ b/cr_electronic_invoice/models/res_partner.py
@@ -12,26 +12,26 @@ class PartnerElectronic(models.Model):
 
     commercial_name = fields.Char(string="Nombre comercial", required=False, )
     state_id = fields.Many2one(
-        comodel_name="res.country.state", string="Provincia", required=False, )
+        "res.country.state", string="Provincia", required=False, )
     district_id = fields.Many2one(
-        comodel_name="res.country.district", string="Distrito", required=False, )
+        "res.country.district", string="Distrito", required=False, )
     county_id = fields.Many2one(
-        comodel_name="res.country.county", string="Cantón", required=False, )
+        "res.country.county", string="Cantón", required=False, )
     neighborhood_id = fields.Many2one(
-        comodel_name="res.country.neighborhood", string="Barrios", required=False, )
-    identification_id = fields.Many2one(comodel_name="identification.type", string="Tipo de identificacion",
+        "res.country.neighborhood", string="Barrios", required=False, )
+    identification_id = fields.Many2one("identification.type", string="Tipo de identificacion",
                                         required=False, )
     payment_methods_id = fields.Many2one(
-        comodel_name="payment.methods", string="Métodos de Pago", required=False, )
+        "payment.methods", string="Métodos de Pago", required=False, )
 
     has_exoneration = fields.Boolean(string="Posee exoneración", required=False)
-    type_exoneration = fields.Many2one(comodel_name="aut.ex", string="Tipo Autorizacion", required=False, )
+    type_exoneration = fields.Many2one("aut.ex", string="Tipo Autorizacion", required=False, )
     exoneration_number = fields.Char(string="Número de exoneración", required=False, )
     institution_name = fields.Char(string="Institucion Emisora", required=False, )
     date_issue = fields.Date(string="Fecha de Emisión", required=False, )
     date_expiration = fields.Date(string="Fecha de Vencimiento", required=False, )
 
-    activity_id = fields.Many2one(comodel_name="economic_activity", string="Actividad Económica",
+    activity_id = fields.Many2one("economic_activity", string="Actividad Económica",
                                   required=False, )
 
     @api.onchange('phone')

--- a/cr_electronic_invoice_pos/models/electronic_invoice.py
+++ b/cr_electronic_invoice_pos/models/electronic_invoice.py
@@ -20,7 +20,7 @@ class AccountJournal(models.Model):
     _inherit = 'account.journal'
 
     payment_method_id = fields.Many2one(
-        comodel_name="payment.methods", string="Payment Methods", required=False, )
+        "payment.methods", string="Payment Methods", required=False, )
 
 
 class PosConfig(models.Model):
@@ -29,14 +29,14 @@ class PosConfig(models.Model):
     sucursal = fields.Integer(string="Sucursal", required=False, default="1")
     terminal = fields.Integer(string="Terminal", required=False, default="1")
 
-    FE_sequence_id = fields.Many2one(comodel_name="ir.sequence",
+    FE_sequence_id = fields.Many2one("ir.sequence",
                                      string="Secuencia de Facturas Electrónicas",
                                      required=False)
     NC_sequence_id = fields.Many2one(oldname='return_sequence_id',
-                                     comodel_name="ir.sequence",
+                                     "ir.sequence",
                                      string="Secuencia de Notas de Crédito Electrónicas",
                                      required=False)
-    TE_sequence_id = fields.Many2one(comodel_name="ir.sequence",
+    TE_sequence_id = fields.Many2one("ir.sequence",
                                      string="Secuencia de Tiquetes Electrónicos",
                                      required=False)
 
@@ -92,9 +92,9 @@ class PosOrder(models.Model):
                                           ('procesando', 'Procesando')], 'Estado FE', copy=False)
 
     reference_code_id = fields.Many2one(
-        comodel_name="reference.code", string="Código de referencia", required=False)
+        "reference.code", string="Código de referencia", required=False)
     pos_order_id = fields.Many2one(
-        comodel_name="pos.order", string="Documento de referencia", required=False, copy=False)
+        "pos.order", string="Documento de referencia", required=False, copy=False)
     xml_respuesta_tributacion = fields.Binary(
         string="Respuesta Tributación XML", required=False, copy=False, attachment=True)
     fname_xml_respuesta_tributacion = fields.Char(

--- a/l10n_cr_country_codes/models/country_codes.py
+++ b/l10n_cr_country_codes/models/country_codes.py
@@ -13,7 +13,7 @@ class ResCountryCounty(models.Model):
     _order = 'name'
 
     code = fields.Char(string="Código", required=True, )
-    state_id = fields.Many2one(comodel_name="res.country.state", string="Provincia", required=True)
+    state_id = fields.Many2one("res.country.state", string="Provincia", required=True)
     name = fields.Char(string="Nombre", required=True, )
 
 
@@ -23,7 +23,7 @@ class ResCountryDistrict(models.Model):
     _order = 'name'
 
     code = fields.Char(string="Código", required=True, )
-    county_id = fields.Many2one(comodel_name="res.country.county", string="Cantón", required=True)
+    county_id = fields.Many2one("res.country.county", string="Cantón", required=True)
     name = fields.Char(string="Nombre", required=True, )
 
 
@@ -33,7 +33,7 @@ class ResCountryNeighborhood(models.Model):
     _order = 'name'
 
     code = fields.Char(string="Código", required=True, )
-    district_id = fields.Many2one(comodel_name="res.country.district", string="Distrito", required=True)
+    district_id = fields.Many2one("res.country.district", string="Distrito", required=True)
     name = fields.Char(string="Nombre", required=True, )
 
 


### PR DESCRIPTION
Sólamente se elimina la hilera comodel_name=
para facilitar el backport sin generar tantas diferencias en versiones previas que no soportan la hilera