### PR TITLE
v12: Grupos de impuestos para reportes factura

### DIFF
--- a/cr_electronic_invoice/data/account_tax_data.xml
+++ b/cr_electronic_invoice/data/account_tax_data.xml
@@ -2,6 +2,72 @@
 <odoo>
     <data noupdate="0">
 
+        <!-- Account Tax Group -->
+        <record id="tax_group_IVA0" model="account.tax.group">
+            <field name="name">IVA 0%</field>
+            <field name="sequence">0</field>
+        </record>
+
+        <record id="tax_group_IVA1" model="account.tax.group">
+            <field name="name">IVA 1%</field>
+            <field name="sequence">0</field>
+        </record>
+
+        <record id="tax_group_IVA2" model="account.tax.group">
+            <field name="name">IVA 2%</field>
+            <field name="sequence">0</field>
+        </record>
+
+        <record id="tax_group_IVA4" model="account.tax.group">
+            <field name="name">IVA 4%</field>
+            <field name="sequence">0</field>
+        </record>
+
+        <record id="tax_group_IVA8" model="account.tax.group">
+            <field name="name">IVA 8%</field>
+            <field name="sequence">0</field>
+        </record>
+
+        <record id="tax_group_IVA13" model="account.tax.group">
+            <field name="name">IVA 13%</field>
+            <field name="sequence">0</field>
+        </record>
+
+        <record id="tax_group_SC" model="account.tax.group">
+            <field name="name">SC</field>
+            <field name="sequence">0</field>
+        </record>
+
+        <record id="tax_group_IUC" model="account.tax.group">
+            <field name="name">IUC</field>
+            <field name="sequence">0</field>
+        </record>
+
+        <record id="tax_group_IEBA" model="account.tax.group">
+            <field name="name">IEBA</field>
+            <field name="sequence">0</field>
+        </record>
+
+        <record id="tax_group_IEBE" model="account.tax.group">
+            <field name="name">IEBE</field>
+            <field name="sequence">0</field>
+        </record>
+
+        <record id="tax_group_IPT" model="account.tax.group">
+            <field name="name">IPT</field>
+            <field name="sequence">0</field>
+        </record>
+
+        <record id="tax_group_IRBU" model="account.tax.group">
+            <field name="name">IRBU</field>
+            <field name="sequence">0</field>
+        </record>
+
+        <record id="tax_group_Servicio" model="account.tax.group">
+            <field name="name">10% Servicio</field>
+            <field name="sequence">0</field>
+        </record>
+
         <!-- account tax -->
         <record id="iva_tax_0" 
             model="account.tax">
@@ -9,6 +75,7 @@
             <field name="name">IVA 0%</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_IVA0"/>
             <field name="description">IVA 0% </field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -22,6 +89,7 @@
             <field name="name">IVA 0% </field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_IVA0"/>
             <field name="description">IVA 0%</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -35,6 +103,7 @@
             <field name="name">IVA</field>
             <field name="amount">13</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_IVA13"/>
             <field name="description">IVA General 13%</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -48,6 +117,7 @@
             <field name="name">IVA</field>
             <field name="amount">13</field>
             <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_IVA13"/>
             <field name="description">IVA General 13%</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -61,6 +131,7 @@
             <field name="name">IVA 1% (Tarifa Reducida)</field>
             <field name="amount">1</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_IVA1"/>
             <field name="description">IVA 1% (Tarifa Reducida)</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -74,6 +145,7 @@
             <field name="name">IVA 1% (Tarifa Reducida)</field>
             <field name="amount">1</field>
             <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_IVA1"/>
             <field name="description">IVA 1% (Tarifa Reducida)</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -87,6 +159,7 @@
             <field name="name">IVA 2% (Tarifa Reducida)</field>
             <field name="amount">2</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_IVA2"/>
             <field name="description">IVA 2% (Tarifa Reducida)</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -100,6 +173,7 @@
             <field name="name">IVA 2% (Tarifa Reducida)</field>
             <field name="amount">2</field>
             <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_IVA2"/>
             <field name="description">IVA 2% (Tarifa Reducida)</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -113,6 +187,7 @@
             <field name="name">IVA 4% (Tarifa Reducida)</field>
             <field name="amount">4</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_IVA4"/>
             <field name="description">IVA 4% (Tarifa Reducida)</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -126,6 +201,7 @@
             <field name="name">IVA 4% (Tarifa Reducida)</field>
             <field name="amount">4</field>
             <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_IVA4"/>
             <field name="description">IVA 4% (Tarifa Reducida)</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -139,6 +215,7 @@
             <field name="name">IVA 0% (Transitorio)</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_IVA0"/>
             <field name="description">IVA 0% (Transitorio)</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -152,6 +229,7 @@
             <field name="name">IVA 0% (Transitorio)</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_IVA0"/>
             <field name="description">IVA 0% (Transitorio)</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -165,6 +243,7 @@
             <field name="name">IVA 4% (Transitorio)</field>
             <field name="amount">4</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_IVA4"/>
             <field name="description">IVA 4% (Transitorio)</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -178,6 +257,7 @@
             <field name="name">IVA 4% (Transitorio)</field>
             <field name="amount">4</field>
             <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_IVA4"/>
             <field name="description">IVA 4% (Transitorio)</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -191,6 +271,7 @@
             <field name="name">IVA 8% (Transitorio)</field>
             <field name="amount">8</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_IVA8"/>
             <field name="description">IVA 8% (Transitorio)</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -204,6 +285,7 @@
             <field name="name">IVA 8% (Transitorio)</field>
             <field name="amount">8</field>
             <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_IVA8"/>
             <field name="description">IVA 8% (Transitorio)</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -217,6 +299,7 @@
             <field name="name">Impuesto Selectivo de Consumo</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_SC"/>
             <field name="description">Impuesto Selectivo de Consumo</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -230,6 +313,7 @@
             <field name="name">Impuesto Selectivo de Consumo</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_SC"/>
             <field name="description">Impuesto Selectivo de Consumo</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -243,6 +327,7 @@
             <field name="name">Impuesto Único a los Combustibles</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_IUC"/>
             <field name="description">Impuesto Único a los Combustibles</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -256,6 +341,7 @@
             <field name="name">Impuesto Único a los Combustibles</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_IUC"/>
             <field name="description">Impuesto Único a los Combustibles</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -269,6 +355,7 @@
             <field name="name">Impuesto específico de Bebidas Alcohólicas</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_IEBA"/>
             <field name="description">Impuesto específico de Bebidas Alcohólicas</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -282,6 +369,7 @@
             <field name="name">Impuesto específico de Bebidas Alcohólicas</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_IEBA"/>
             <field name="description">Impuesto específico de Bebidas Alcohólicas</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -296,6 +384,7 @@
     contenido alcohólico y jabones de tocador</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_IEBE"/>
             <field name="description">Impuesto Específico sobre las bebidas envasadas sin
     contenido alcohólico y jabones de tocador</field>
             <field name="sequence">10</field>
@@ -311,6 +400,7 @@
     contenido alcohólico y jabones de tocador</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_IEBE"/>
             <field name="description">Impuesto Específico sobre las bebidas envasadas sin
     contenido alcohólico y jabones de tocador</field>
             <field name="sequence">10</field>
@@ -325,6 +415,7 @@
             <field name="name">Impuesto a los Productos de Tabaco</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_IPT"/>
             <field name="description">Impuesto a los Productos de Tabaco</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -338,6 +429,7 @@
             <field name="name">Impuesto a los Productos de Tabaco</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_IPT"/>
             <field name="description">Impuesto a los Productos de Tabaco</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -351,6 +443,7 @@
             <field name="name">IVA (cálculo especial)</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_IVA13"/>
             <field name="description">IVA (cálculo especial)</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -364,6 +457,7 @@
             <field name="name">IVA (cálculo especial)</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_IVA13"/>
             <field name="description">IVA (cálculo especial)</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -377,6 +471,7 @@
             <field name="name">IVA Régimen de Bienes Usados (Factor)</field>
             <field name="amount">0</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_IRBU"/>
             <field name="description">IVA Régimen de Bienes Usados (Factor)</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -390,6 +485,7 @@
             <field name="name">IVA Régimen de Bienes Usados (Factor)</field>
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
+            <field name="tax_group_id" ref="tax_group_IRBU"/>
             <field name="description">IVA Régimen de Bienes Usados (Factor)</field>
             <field name="sequence">10</field>
             <field name="price_include">False</field>
@@ -455,6 +551,7 @@
             <field name="name">Impuesto de Servicio</field>
             <field name="amount">10</field>
             <field name="type_tax_use">sale</field>
+            <field name="tax_group_id" ref="tax_group_Servicio"/>
             <field name="description">Impuesto de servicio utilizado por los restraurantes</field>
             <field name="sequence">10</field>
             <field name="iva_tax_desc">Impuesto Servicio 10%</field>

--- a/cr_electronic_invoice/data/payment_methods_data.xml
+++ b/cr_electronic_invoice/data/payment_methods_data.xml
@@ -23,7 +23,7 @@
 
         <record id="cr_electronic_invoice.PaymentMethods_4" model="payment.methods">
             <field name="sequence">04</field>
-            <field name="name">Transferencia – depósito bancario</field>
+            <field name="name">Transferencia – depósito</field>
             <field name="active">true</field>
         </record>
 

--- a/cr_electronic_invoice_qweb_fe/views/report_sales_invoice_qweb.xml
+++ b/cr_electronic_invoice_qweb_fe/views/report_sales_invoice_qweb.xml
@@ -7,9 +7,6 @@
 <template id="sale_stock.report_invoice_document_inherit_sale_stock" inherit_id="account.report_invoice_document">
 </template>
 
-<template id="account_payment_partner.report_invoice_payment_mode" inherit_id="account.report_invoice_document">
-</template>
-
 <template id="account.report_invoice_document_with_payments" inherit_id="account.report_invoice_document">
 </template>
 
@@ -33,7 +30,7 @@
                     </span><br/>
                     <span>Tel.</span> <t t-esc="o.company_id.phone"/><br/>
                     <t t-esc="o.company_id.email"/><br/>
-                    <t t-esc="o.company_id.website"/><br/><br/>
+                    <t t-if="o.company_id.website" t-esc="o.company_id.website"/>
                 </td>
                 <td width="30%">
                 <div class="text-center">
@@ -66,9 +63,9 @@
                         <td class="text-center">HORA</td>
                     </tr>
                     <tr>
-                        <td class="dtcls text-center dtbg"><span t-esc="o.date_issuance and (o.date_issuance[8:10]) or o.date_invoice and (o.date_invoice[8:10]) or ''"/></td>
-                        <td class="dtcls text-center dtbg"><span t-esc="o.date_issuance and (o.date_issuance[5:7]) or o.date_invoice and (o.date_invoice[5:7]) or ''"/></td>
-                        <td class="dtcls text-center dtbg"><span t-esc="o.date_issuance and (o.date_issuance[0:4]) or o.date_invoice and (o.date_invoice[0:4]) or ''"/></td>
+                        <td class="dtcls text-center dtbg"><span t-esc="o.date_issuance and (o.date_issuance[8:10]) or o.date_invoice and (o.date_invoice.strftime('%Y/%m/%d')[8:10]) or ''"/></td>
+                        <td class="dtcls text-center dtbg"><span t-esc="o.date_issuance and (o.date_issuance[5:7]) or o.date_invoice and (o.date_invoice.strftime('%Y/%m/%d')[5:7]) or ''"/></td>
+                        <td class="dtcls text-center dtbg"><span t-esc="o.date_issuance and (o.date_issuance[0:4]) or o.date_invoice and (o.date_invoice.strftime('%Y/%m/%d')[0:4]) or ''"/></td>
                         <td class="dtcls text-center dtbg"><span t-esc="o.date_issuance and (o.date_issuance[11:16]) or ''"/></td>
                     </tr>
                     </table>
@@ -241,7 +238,7 @@
                 <t t-set="display_discount" t-value="any([l.discount for l in o.invoice_line_ids])"/>
             <br/>
             <div class="content">
-                <table cellspacing="0" style="height:120mm;width:100%;" class="mt30 mb30">
+                <table cellspacing="0" style="height:100mm;width:100%;" class="mt30 mb30">
                 <!--thead class="bb bt tble-header"-->
                 <thead class="tble-header">
                         <tr>
@@ -373,7 +370,7 @@
                         trámites de juicio ejecutivo. Esta factura devengará 3% mensual después de su vencimiento.
                     </p>
                     <t t-if="o.company_id.html_bank_account1 or o.company_id.html_bank_account2">
-                        <p>Puede realizar transferencias o depósitos mediante las siguientes Cuentas Bancarias de <t t-esc="o.company_id.commercial_name"/>:</p>
+                        Puede realizar transferencias o depósitos mediante las siguientes Cuentas Bancarias de <t t-esc="o.company_id.commercial_name"/>:
                         <table width="100%;" cellpadding="0" cellspacing="0">
                             <tr>
                                 <td width="50%"> <t t-raw="o.company_id.html_bank_account1"/>
@@ -394,11 +391,12 @@
                                 </td>
                             </tr>
                         </table>
-                        <p><strong>CONFIRMACIONES:</strong> Para enviar confirmaciones de depósito    Correo:   <span t-field="o.company_id.email"/></p>
+                        <strong>CONFIRMACIONES:</strong> Para enviar confirmaciones de depósito    Correo:   <span t-field="o.company_id.email"/>
                     </t>
                 </div>
-                <p class="text-center" style="padding:2px 2px 2px 2px">Clave:<span t-field="o.number_electronic"/> // Usuario:<span t-field="o.create_uid.name"/></p>
-                <p class="text-center" style="padding:2px 2px 2px 2px">Autorizada mediante resolución No DGT-R-48-2016 del 7 de octubre de 2016</p>
+                <p class="text-center" style="padding:2px 2px 2px 2px">
+                  Clave:<span t-field="o.number_electronic"/> // Usuario:<span t-field="o.create_uid.name"/><br/>
+                  Autorizada mediante resolución No DGT-R-48-2016 del 7 de octubre de 2016</p>
             </t>
             <link href="http://fonts.googleapis.com/css?family=Droid+Sans" rel="stylesheet" type="text/css"/>
             <style type="text/css">


### PR DESCRIPTION
Se agregar grupos de impuestos, que en v12 se utilizan para mostrar de forma separada los diferentes grupos en el detalle de las facturas impresas

Además se corrigen detalles del qweb de la factura