### PR TITLE
Fix for DIMEX

### DIFF
--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -141,7 +141,7 @@ def get_clave_hacienda(doc, tipo_documento, consecutivo, sucursal_id, terminal_i
     elif doc.company_id.identification_id.code == '02' and len(inv_cedula) != 10:
         raise UserError(
             'La Cédula Jurídica del emisor debe de tener 10 dígitos')
-    elif doc.company_id.identification_id.code == '03' and (len(inv_cedula) != 11 or len(inv_cedula) != 12):
+    elif doc.company_id.identification_id.code == '03' and len(inv_cedula) not in (11, 12):
         raise UserError(
             'La identificación DIMEX del emisor debe de tener 11 o 12 dígitos')
     elif doc.company_id.identification_id.code == '04' and len(inv_cedula) != 10:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Invoices with DIMEX issuer throws a message that the DIMEX must be have 11 or 12 lenght, but lenght is correct
Current behavior before PR:
Valid DIMEX can't be used
Desired behavior after PR is merged:
You can issue invoices with DIMEX issuer