### PR TITLE
Fix currency update display, convert token to password field

### DIFF
--- a/res_currency_cr_adapter/models/res_config_settings.py
+++ b/res_currency_cr_adapter/models/res_config_settings.py
@@ -7,7 +7,7 @@ from odoo import _, api, fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    exchange_source = fields.Selection([('bccr','BCCR (recomendado)'),('hacienda','Hacienda')],required=True,default='bccr')
+    exchange_source = fields.Selection([('disabled','Deshabilitado'),('bccr','BCCR (recomendado)'),('hacienda','Hacienda')],required=True,default='disabled')
     bccr_username = fields.Char(string="Nombre de usuario del BCCR", required=False, )
     bccr_email = fields.Char(string="e-mail registrado en el BCCR", required=False, )
     bccr_token = fields.Char(string="Token para utilizar en el BCCR", required=False, )

--- a/res_currency_cr_adapter/models/res_config_settings.py
+++ b/res_currency_cr_adapter/models/res_config_settings.py
@@ -7,6 +7,7 @@ from odoo import _, api, fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
+    exchange_source = fields.Selection([('bccr','BCCR (recomendado)'),('hacienda','Hacienda')],required=True,default='bccr')
     bccr_username = fields.Char(string="Nombre de usuario del BCCR", required=False, )
     bccr_email = fields.Char(string="e-mail registrado en el BCCR", required=False, )
     bccr_token = fields.Char(string="Token para utilizar en el BCCR", required=False, )
@@ -20,6 +21,7 @@ class ResConfigSettings(models.TransientModel):
             bccr_username=get_param('bccr_username'),
             bccr_email=get_param('bccr_email'),
             bccr_token=get_param('bccr_token'),
+            exchange_source=get_param('exchange_source'),
         )
         return res
 
@@ -30,4 +32,5 @@ class ResConfigSettings(models.TransientModel):
         set_param('bccr_username', self.bccr_username)
         set_param('bccr_email', self.bccr_email)
         set_param('bccr_token', self.bccr_token)
+        set_param('exchange_source', self.exchange_source)
 

--- a/res_currency_cr_adapter/models/res_currency.py
+++ b/res_currency_cr_adapter/models/res_currency.py
@@ -9,6 +9,7 @@ from xmlrpc.client import ServerProxy
 import datetime
 import xml.etree.ElementTree
 import logging
+import requests
 
 _logger = logging.getLogger(__name__)
 
@@ -47,93 +48,131 @@ class ResCurrencyRate(models.Model):
             "=========================================================")
         _logger.debug("Executing exchange rate update from 1 CRC = X USD")
 
-        bccr_username = self.env['ir.config_parameter'].sudo().get_param('bccr_username')
-        bccr_email = self.env['ir.config_parameter'].sudo().get_param('bccr_email')
-        bccr_token = self.env['ir.config_parameter'].sudo().get_param('bccr_token')
+        exchange_source = self.env['ir.config_parameter'].sudo().get_param('exchange_source')
+        if exchange_source == 'bccr':
+            bccr_username = self.env['ir.config_parameter'].sudo().get_param('bccr_username')
+            bccr_email = self.env['ir.config_parameter'].sudo().get_param('bccr_email')
+            bccr_token = self.env['ir.config_parameter'].sudo().get_param('bccr_token')
 
-        # Get current date to get exchange rate for today
-        currentDate = datetime.datetime.now().date()
-        # formato requerido por el BCCR dd/mm/yy
-        today = currentDate.strftime('%d/%m/%Y')
+            # Get current date to get exchange rate for today
+            currentDate = datetime.datetime.now().date()
+            # formato requerido por el BCCR dd/mm/yy
+            today = currentDate.strftime('%d/%m/%Y')
 
-        # Get XML Schema for BCCR webservice SOAP
-        imp = Import('http://www.w3.org/2001/XMLSchema', location='http://www.w3.org/2001/XMLSchema.xsd')
-        imp.filter.add('http://ws.sdde.bccr.fi.cr')
+            # Get XML Schema for BCCR webservice SOAP
+            imp = Import('http://www.w3.org/2001/XMLSchema', location='http://www.w3.org/2001/XMLSchema.xsd')
+            imp.filter.add('http://ws.sdde.bccr.fi.cr')
 
-        # Web Service Connection using the XML schema from BCCRR
-        client = Client('https://gee.bccr.fi.cr/Indicadores/Suscripciones/WS/wsindicadoreseconomicos.asmx?WSDL', doctor=ImportDoctor(imp))
+            # Web Service Connection using the XML schema from BCCRR
+            client = Client('https://gee.bccr.fi.cr/Indicadores/Suscripciones/WS/wsindicadoreseconomicos.asmx?WSDL', doctor=ImportDoctor(imp))
 
-        # The response is a string we need to convert it to XML to extract value
+            # The response is a string we need to convert it to XML to extract value
 
-        response = client.service.ObtenerIndicadoresEconomicosXML(Indicador='318',
-                                                                  FechaInicio=today,
-                                                                  FechaFinal=today,
-                                                                  Nombre=bccr_username,
-                                                                  SubNiveles='N',
-                                                                  CorreoElectronico=bccr_email,
-                                                                  Token=bccr_token)
-        xmlResponse = xml.etree.ElementTree.fromstring(response)
-        rateNodes = xmlResponse.findall("./INGC011_CAT_INDICADORECONOMIC/NUM_VALOR")
-        sellingRate = 0
-        if len(rateNodes) > 0:
-            sellingOriginalRate = float(rateNodes[0].text)
-            # Odoo uses the value of 1 unit of the base currency divided between the exchage rate
-            sellingRate = 1 / sellingOriginalRate
+            response = client.service.ObtenerIndicadoresEconomicosXML(Indicador='318',
+                                                                      FechaInicio=today,
+                                                                      FechaFinal=today,
+                                                                      Nombre=bccr_username,
+                                                                      SubNiveles='N',
+                                                                      CorreoElectronico=bccr_email,
+                                                                      Token=bccr_token)
+            xmlResponse = xml.etree.ElementTree.fromstring(response)
+            rateNodes = xmlResponse.findall("./INGC011_CAT_INDICADORECONOMIC/NUM_VALOR")
+            sellingRate = 0
+            if len(rateNodes) > 0:
+                sellingOriginalRate = float(rateNodes[0].text)
+                # Odoo uses the value of 1 unit of the base currency divided between the exchage rate
+                sellingRate = 1 / sellingOriginalRate
 
-        # Get Buying exchange Rate from BCCR
-        response = client.service.ObtenerIndicadoresEconomicosXML(Indicador='317',
-                                                                  FechaInicio=today,
-                                                                  FechaFinal=today,
-                                                                  Nombre=bccr_username,
-                                                                  SubNiveles='N',
-                                                                  CorreoElectronico=bccr_email,
-                                                                  Token=bccr_token)
+            # Get Buying exchange Rate from BCCR
+            response = client.service.ObtenerIndicadoresEconomicosXML(Indicador='317',
+                                                                      FechaInicio=today,
+                                                                      FechaFinal=today,
+                                                                      Nombre=bccr_username,
+                                                                      SubNiveles='N',
+                                                                      CorreoElectronico=bccr_email,
+                                                                      Token=bccr_token)
 
-        xmlResponse = xml.etree.ElementTree.fromstring(response)
-        rateNodes = xmlResponse.findall("./INGC011_CAT_INDICADORECONOMIC/NUM_VALOR")
-        buyingRate = 0
-        if len(rateNodes) > 0:
-            buyingOriginalRate = float(rateNodes[0].text)
-            # Odoo uses the value of 1 unit of the base currency divided between the exchage rate
-            buyingRate = 1 / buyingOriginalRate
+            xmlResponse = xml.etree.ElementTree.fromstring(response)
+            rateNodes = xmlResponse.findall("./INGC011_CAT_INDICADORECONOMIC/NUM_VALOR")
+            buyingRate = 0
+            if len(rateNodes) > 0:
+                buyingOriginalRate = float(rateNodes[0].text)
+                # Odoo uses the value of 1 unit of the base currency divided between the exchage rate
+                buyingRate = 1 / buyingOriginalRate
 
-        # Save the exchange rate in database
-        today = currentDate.strftime('%Y-%m-%d')
+            # Save the exchange rate in database
+            today = currentDate.strftime('%Y-%m-%d')
 
-        # GET THE CURRENCY ID
-        currency_id = self.env['res.currency'].search([('name', '=', 'USD')], limit=1)
+            # GET THE CURRENCY ID
+            currency_id = self.env['res.currency'].search([('name', '=', 'USD')], limit=1)
 
-        # Get the rate for this date to know it is already registered
-        ratesIds = self.env['res.currency.rate'].search([('name', '=', today)], limit=1)
+            # Get the rate for this date to know it is already registered
+            ratesIds = self.env['res.currency.rate'].search([('name', '=', today)], limit=1)
 
-        if len(ratesIds) > 0:
-            newRate = ratesIds.write({'rate': sellingRate,
-                                      'original_rate': sellingOriginalRate,
-                                      'rate_2': buyingRate,
-                                      'original_rate_2': buyingOriginalRate,
-                                      'currency_id': currency_id.id})
-            _logger.debug({'name': today,
-                           'rate': sellingRate,
-                           'original_rate': sellingOriginalRate,
-                           'rate_2': buyingRate,
-                           'original_rate_2': buyingOriginalRate,
-                           'currency_id': currency_id.id})
-        else:
-            newRate = self.create({'name': today,
-                                   'rate': sellingRate,
-                                   'original_rate': sellingOriginalRate,
-                                   'rate_2': buyingRate,
-                                   'original_rate_2': buyingOriginalRate,
-                                   'currency_id': currency_id.id})
-            _logger.debug({'name': today,
-                           'rate': sellingRate,
-                           'original_rate': sellingOriginalRate,
-                           'rate_2': buyingRate,
-                           'original_rate_2': buyingOriginalRate,
-                           'currency_id': currency_id.id})
+            if len(ratesIds) > 0:
+                newRate = ratesIds.write({'rate': sellingRate,
+                                          'original_rate': sellingOriginalRate,
+                                          'rate_2': buyingRate,
+                                          'original_rate_2': buyingOriginalRate,
+                                          'currency_id': currency_id.id})
+                _logger.debug({'name': today,
+                               'rate': sellingRate,
+                               'original_rate': sellingOriginalRate,
+                               'rate_2': buyingRate,
+                               'original_rate_2': buyingOriginalRate,
+                               'currency_id': currency_id.id})
+            else:
+                newRate = self.create({'name': today,
+                                       'rate': sellingRate,
+                                       'original_rate': sellingOriginalRate,
+                                       'rate_2': buyingRate,
+                                       'original_rate_2': buyingOriginalRate,
+                                       'currency_id': currency_id.id})
+                _logger.debug({'name': today,
+                               'rate': sellingRate,
+                               'original_rate': sellingOriginalRate,
+                               'rate_2': buyingRate,
+                               'original_rate_2': buyingOriginalRate,
+                               'currency_id': currency_id.id})
 
-        _logger.debug(
-            "=========================================================")
+            _logger.debug(
+                "=========================================================")
+
+        if exchange_source == 'hacienda':
+            _logger.info("=========================================================")
+            _logger.info("Executing exchange rate update")
+
+            try:
+                url = 'https://api.hacienda.go.cr/indicadores/tc'
+                response = requests.get(url, timeout=5, verify=False)
+
+            except requests.exceptions.RequestException as e:
+                _logger.info('RequestException %s' % e)
+                return False
+
+            if response.status_code in (200,):
+                # Save the exchange rate in database
+                today = datetime.datetime.now().strftime('%Y-%m-%d')
+                data = response.json()
+
+                vals = {}
+                vals['original_rate'] = data['dolar']['venta']['valor']
+                # Odoo utiliza un valor inverso, a cuantos dólares equivale 1 colón, por eso se divide 1 / tipo de cambio.
+                vals['rate'] =  1 / vals['original_rate']
+                vals['original_rate_2'] = data['dolar']['compra']['valor']
+                vals['rate_2'] = 1 / vals['original_rate_2']
+                vals['currency_id'] = self.env.ref('base.USD').id
+
+                rate_id = self.env['res.currency.rate'].search([('name', '=', today)], limit=1)
+
+                if rate_id:
+                    rate_id.write(vals)
+                else:
+                    vals['name'] = today
+                    self.create(vals)
+
+            _logger.info(vals)
+            _logger.info("=========================================================")
 
     @api.model
     def _cron_update_crc2usd_rate(self):

--- a/res_currency_cr_adapter/views/res_config_settings_views.xml
+++ b/res_currency_cr_adapter/views/res_config_settings_views.xml
@@ -6,14 +6,13 @@
             <field name="model">res.config.settings</field>
             <field name="inherit_id" ref="account.res_config_settings_view_form"/>
             <field name="arch" type="xml">
-            
                 <xpath expr="//field[@name='currency_exchange_journal_id']" position="after">
-                        <div class="o_form_label .col-lg-3">User name registered in the BCCR</div>
+                        <div class="o_form_label col-lg-3 o_light_label">Username registered in the BCCR</div>
                         <field name="bccr_username" string="User name registered in the BCCR" />
-                        <div class="o_form_label">email registered in the BCCR</div>
+                        <div class="o_form_label col-lg-3 o_light_label">Email registered in the BCCR</div>
                         <field name="bccr_email" string="email registered in the BCCR" />
-                        <div class="o_form_label">BCCR Token</div>
-                        <field name="bccr_token" string="BCCR Token" />
+                        <div class="o_form_label col-lg-3 o_light_label">BCCR Token</div>
+                        <field name="bccr_token" string="BCCR Token" password="True" />
                 </xpath>
            </field>
         </record>

--- a/res_currency_cr_adapter/views/res_config_settings_views.xml
+++ b/res_currency_cr_adapter/views/res_config_settings_views.xml
@@ -7,12 +7,14 @@
             <field name="inherit_id" ref="account.res_config_settings_view_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='currency_exchange_journal_id']" position="after">
-                        <div class="o_form_label col-lg-3 o_light_label">Username registered in the BCCR</div>
-                        <field name="bccr_username" string="User name registered in the BCCR" />
-                        <div class="o_form_label col-lg-3 o_light_label">Email registered in the BCCR</div>
-                        <field name="bccr_email" string="email registered in the BCCR" />
-                        <div class="o_form_label col-lg-3 o_light_label">BCCR Token</div>
-                        <field name="bccr_token" string="BCCR Token" password="True" />
+                        <div class="o_form_label col-lg-3 o_light_label">Origen del tipo de cambio</div>
+                        <field name="exchange_source" string="Origen del tipo de cambio"/>
+                        <div attrs="{'invisible':[('exchange_source', '=', 'hacienda')]}" class="o_form_label col-lg-3 o_light_label">Username registered in the BCCR</div>
+                        <field attrs="{'invisible':[('exchange_source', '=', 'hacienda')]}" name="bccr_username" string="User name registered in the BCCR" />
+                        <div attrs="{'invisible':[('exchange_source', '=', 'hacienda')]}" class="o_form_label col-lg-3 o_light_label">Email registered in the BCCR</div>
+                        <field attrs="{'invisible':[('exchange_source', '=', 'hacienda')]}" name="bccr_email" string="email registered in the BCCR" />
+                        <div attrs="{'invisible':[('exchange_source', '=', 'hacienda')]}" class="o_form_label col-lg-3 o_light_label">BCCR Token</div>
+                        <field attrs="{'invisible':[('exchange_source', '=', 'hacienda')]}" name="bccr_token" string="BCCR Token" password="True" />
                 </xpath>
            </field>
         </record>

--- a/res_currency_cr_adapter/views/res_config_settings_views.xml
+++ b/res_currency_cr_adapter/views/res_config_settings_views.xml
@@ -9,12 +9,12 @@
                 <xpath expr="//field[@name='currency_exchange_journal_id']" position="after">
                         <div class="o_form_label col-lg-3 o_light_label">Origen del tipo de cambio</div>
                         <field name="exchange_source" string="Origen del tipo de cambio"/>
-                        <div attrs="{'invisible':[('exchange_source', '=', 'hacienda')]}" class="o_form_label col-lg-3 o_light_label">Username registered in the BCCR</div>
-                        <field attrs="{'invisible':[('exchange_source', '=', 'hacienda')]}" name="bccr_username" string="User name registered in the BCCR" />
-                        <div attrs="{'invisible':[('exchange_source', '=', 'hacienda')]}" class="o_form_label col-lg-3 o_light_label">Email registered in the BCCR</div>
-                        <field attrs="{'invisible':[('exchange_source', '=', 'hacienda')]}" name="bccr_email" string="email registered in the BCCR" />
-                        <div attrs="{'invisible':[('exchange_source', '=', 'hacienda')]}" class="o_form_label col-lg-3 o_light_label">BCCR Token</div>
-                        <field attrs="{'invisible':[('exchange_source', '=', 'hacienda')]}" name="bccr_token" string="BCCR Token" password="True" />
+                        <div attrs="{'invisible':[('exchange_source', '!=', 'bccr'')]}" class="o_form_label col-lg-3 o_light_label">Username registered in the BCCR</div>
+                        <field attrs="{'invisible':[('exchange_source', '!=', 'bccr'')]}" name="bccr_username" string="User name registered in the BCCR" />
+                        <div attrs="{'invisible':[('exchange_source', '!=', 'bccr'')]}" class="o_form_label col-lg-3 o_light_label">Email registered in the BCCR</div>
+                        <field attrs="{'invisible':[('exchange_source', '!=', 'bccr'')]}" name="bccr_email" string="email registered in the BCCR" />
+                        <div attrs="{'invisible':[('exchange_source', '!=', 'bccr'')]}" class="o_form_label col-lg-3 o_light_label">BCCR Token</div>
+                        <field attrs="{'invisible':[('exchange_source', '!=', 'bccr'')]}" name="bccr_token" string="BCCR Token" password="True" />
                 </xpath>
            </field>
         </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fix currency update display, convert token to password field

Current behavior before PR:
The fields about BCCR currency exchange are bad displayed

Desired behavior after PR is merged:
The fields about BCCR currency exchange are better displayed
Token field doesn't display info