### PR TITLE
Fix Impuesto Selectivo de Consumo

### DIFF
--- a/cr_electronic_invoice/data/account_tax_data.xml
+++ b/cr_electronic_invoice/data/account_tax_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data noupdate="1">
+    <data noupdate="0">
 
         <!-- Account Tax Group -->
         <record id="tax_group_IVA0" model="account.tax.group">
@@ -382,7 +382,7 @@
             <field name="type_tax_use">sale</field>
             <field name="tax_group_id" ref="tax_group_SC"/>
             <field name="description">Impuesto Selectivo de Consumo</field>
-            <field name="sequence">10</field>
+            <field name="sequence">5</field>
             <field name="iva_tax_desc">N/A</field>
             <field name="iva_tax_code">N/A</field>
         </record>
@@ -394,7 +394,7 @@
             <field name="type_tax_use">purchase</field>
             <field name="tax_group_id" ref="tax_group_SC"/>
             <field name="description">Impuesto Selectivo de Consumo</field>
-            <field name="sequence">10</field>
+            <field name="sequence">5</field>
             <field name="iva_tax_desc">N/A</field>
             <field name="iva_tax_code">N/A</field>
         </record>
@@ -405,7 +405,7 @@
             <field name="amount">0</field>
             <field name="type_tax_use">purchase</field>
             <field name="description">Impuesto Selectivo de Consumo (No deducible)</field>
-            <field name="sequence">10</field>
+            <field name="sequence">5</field>
             <field name="iva_tax_desc">N/A</field>
             <field name="iva_tax_code">N/A</field>
             <field name="tax_group_id" ref="tax_group_IVA_ND"/>

--- a/cr_electronic_invoice/models/account_invoice.py
+++ b/cr_electronic_invoice/models/account_invoice.py
@@ -1154,7 +1154,7 @@ class AccountInvoiceElectronic(models.Model):
                                 elif taxes_lookup[i['id']]['tax_code'] != '00':
                                     tax_index += 1
                                     # tax_amount = round(i['amount'], 5) * quantity
-                                    tax_amount = round(subtotal_line * taxes_lookup[i['id']]['tarifa'] / 100, 5)
+                                    tax_amount = round(i['base'] * taxes_lookup[i['id']]['tarifa'] / 100, 5)
                                     _line_tax += tax_amount
                                     tax = {
                                         'codigo': taxes_lookup[i['id']]['tax_code'],

--- a/cr_electronic_invoice/models/account_invoice.py
+++ b/cr_electronic_invoice/models/account_invoice.py
@@ -1331,7 +1331,7 @@ class AccountInvoiceElectronic(models.Model):
                 super(AccountInvoiceElectronic, inv).action_invoice_open()
                 inv.tipo_documento = None
                 continue
-            
+
             if inv.partner_id.has_exoneration and inv.partner_id.date_expiration and (inv.partner_id.date_expiration < datetime.date.today()):
                 raise UserError('La exoneración de este cliente se encuentra vencida')
 

--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -550,8 +550,8 @@ def gen_xml_v43(inv, sale_conditions, total_servicio_gravado,
                 sb.Append('<Codigo>' + str(b['codigo']) + '</Codigo>')
                 if tax_code.isdigit():
                     sb.Append('<CodigoTarifa>' + tax_code + '</CodigoTarifa>')
-            sb.Append('<Tarifa>' + str(b['tarifa']) + '</Tarifa>')
-            sb.Append('<Monto>' + str(b['monto']) + '</Monto>')
+                sb.Append('<Tarifa>' + str(b['tarifa']) + '</Tarifa>')
+                sb.Append('<Monto>' + str(b['monto']) + '</Monto>')
 
                 if inv.tipo_documento != 'FEE':
                     if b.get('exoneracion'):

--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -546,24 +546,24 @@ def gen_xml_v43(inv, sale_conditions, total_servicio_gravado,
         if v.get('impuesto'):
             for (a, b) in v['impuesto'].items():
                 tax_code = str(b['iva_tax_code'])
+                sb.Append('<Impuesto>')
+                sb.Append('<Codigo>' + str(b['codigo']) + '</Codigo>')
                 if tax_code.isdigit():
-                    sb.Append('<Impuesto>')
-                    sb.Append('<Codigo>' + str(b['codigo']) + '</Codigo>')
                     sb.Append('<CodigoTarifa>' + tax_code + '</CodigoTarifa>')
-                    sb.Append('<Tarifa>' + str(b['tarifa']) + '</Tarifa>')
-                    sb.Append('<Monto>' + str(b['monto']) + '</Monto>')
+            sb.Append('<Tarifa>' + str(b['tarifa']) + '</Tarifa>')
+            sb.Append('<Monto>' + str(b['monto']) + '</Monto>')
 
-                    if inv.tipo_documento != 'FEE':
-                        if b.get('exoneracion'):
-                            sb.Append('<Exoneracion>')
-                            sb.Append('<TipoDocumento>' + receiver_company.type_exoneration.code + '</TipoDocumento>')
-                            sb.Append('<NumeroDocumento>' + receiver_company.exoneration_number + '</NumeroDocumento>')
-                            sb.Append('<NombreInstitucion>' + receiver_company.institution_name + '</NombreInstitucion>')
-                            sb.Append('<FechaEmision>' + str(receiver_company.date_issue) + 'T00:00:00-06:00' + '</FechaEmision>')
-                            sb.Append('<PorcentajeExoneracion>' + str(b['exoneracion']['porcentajeCompra']) + '</PorcentajeExoneracion>')
-                            sb.Append('<MontoExoneracion>' + str(b['exoneracion']['montoImpuesto']) + '</MontoExoneracion>')
-                            sb.Append('</Exoneracion>')
-                    sb.Append('</Impuesto>')
+                if inv.tipo_documento != 'FEE':
+                    if b.get('exoneracion'):
+                        sb.Append('<Exoneracion>')
+                        sb.Append('<TipoDocumento>' + receiver_company.type_exoneration.code + '</TipoDocumento>')
+                        sb.Append('<NumeroDocumento>' + receiver_company.exoneration_number + '</NumeroDocumento>')
+                        sb.Append('<NombreInstitucion>' + receiver_company.institution_name + '</NombreInstitucion>')
+                        sb.Append('<FechaEmision>' + str(receiver_company.date_issue) + 'T00:00:00-06:00' + '</FechaEmision>')
+                        sb.Append('<PorcentajeExoneracion>' + str(b['exoneracion']['porcentajeCompra']) + '</PorcentajeExoneracion>')
+                        sb.Append('<MontoExoneracion>' + str(b['exoneracion']['montoImpuesto']) + '</MontoExoneracion>')
+                        sb.Append('</Exoneracion>')
+                sb.Append('</Impuesto>')
 
             sb.Append('<ImpuestoNeto>' + str(v['impuestoNeto']) + '</ImpuestoNeto>')
 


### PR DESCRIPTION
Corrige el calculo del Impuesto selectivo de consumo para el XML de Hacienda.

Para que odoo lo calcule de forma correcta ir a FACTURACION - CONFIGURACION - IMPUESTOS
Luego mover hacia la primera línea el Impuesto Selectivo de Consumo, como se muestra en la imagen.

![ISC](https://user-images.githubusercontent.com/43304744/108440060-15798880-7218-11eb-914a-0f8ddf9c8b91.png)
