### PR TITLE
Add missing button for resend mails of pos ordersn from backend

### DIFF
--- a/cr_electronic_invoice_pos/views/electronic_invoice_views.xml
+++ b/cr_electronic_invoice_pos/views/electronic_invoice_views.xml
@@ -96,6 +96,9 @@
                         <field name="message_ids" widget="mail_thread"/>
                     </div>
                 </xpath>
+                <xpath expr="//button[@name='refund']" position="after">
+                    <button name="action_invoice_sent" type="object" string="Re-send mail" attrs="{'invisible':[('state_tributacion','!=','aceptado')]}"/>
+                </xpath>
             </field>
         </record>
         <record id="view_pos_order_electronic_invoice_tree" model="ir.ui.view">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged: