### PR TITLE
[12.0] Fixing the issue #246.

### DIFF
--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -406,7 +406,7 @@ def gen_xml_v43(inv, sale_conditions, total_servicio_gravado,
     sb.Append('<NumeroConsecutivo>' + inv.number_electronic[21:41] + '</NumeroConsecutivo>')
     sb.Append('<FechaEmision>' + inv.date_issuance + '</FechaEmision>')
     sb.Append('<Emisor>')
-    sb.Append('<Nombre>' + escape(issuing_company.name) + '</Nombre>')
+    sb.Append('<Nombre>' + escape(issuing_company.legal_name) + '</Nombre>')
     sb.Append('<Identificacion>')
     sb.Append('<Tipo>' + issuing_company.identification_id.code + '</Tipo>')
     sb.Append('<Numero>' + issuing_company.vat + '</Numero>')

--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -406,7 +406,10 @@ def gen_xml_v43(inv, sale_conditions, total_servicio_gravado,
     sb.Append('<NumeroConsecutivo>' + inv.number_electronic[21:41] + '</NumeroConsecutivo>')
     sb.Append('<FechaEmision>' + inv.date_issuance + '</FechaEmision>')
     sb.Append('<Emisor>')
-    sb.Append('<Nombre>' + escape(issuing_company.legal_name) + '</Nombre>')
+    if issuing_company.legal_name:
+        sb.Append('<Nombre>' + escape(issuing_company.legal_name) + '</Nombre>')
+    else:
+        sb.Append('<Nombre>' + escape(issuing_company.name) + '</Nombre>')
     sb.Append('<Identificacion>')
     sb.Append('<Tipo>' + issuing_company.identification_id.code + '</Tipo>')
     sb.Append('<Numero>' + issuing_company.vat + '</Numero>')

--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -406,10 +406,7 @@ def gen_xml_v43(inv, sale_conditions, total_servicio_gravado,
     sb.Append('<NumeroConsecutivo>' + inv.number_electronic[21:41] + '</NumeroConsecutivo>')
     sb.Append('<FechaEmision>' + inv.date_issuance + '</FechaEmision>')
     sb.Append('<Emisor>')
-    if issuing_company.legal_name:
-        sb.Append('<Nombre>' + escape(issuing_company.legal_name) + '</Nombre>')
-    else:
-        sb.Append('<Nombre>' + escape(issuing_company.name) + '</Nombre>')
+    sb.Append('<Nombre>' + escape(issuing_company.legal_name or issuing_company.name) + '</Nombre>')
     sb.Append('<Identificacion>')
     sb.Append('<Tipo>' + issuing_company.identification_id.code + '</Tipo>')
     sb.Append('<Numero>' + issuing_company.vat + '</Numero>')

--- a/cr_electronic_invoice/models/res_company.py
+++ b/cr_electronic_invoice/models/res_company.py
@@ -29,6 +29,7 @@ class CompanyElectronic(models.Model):
     _inherit = ['res.company', 'mail.thread', ]
 
     commercial_name = fields.Char(string="Commercial Name", required=False, )
+    legal_name = fields.Char(string="Nombre Legal", required=False)
     activity_id = fields.Many2one("economic.activity", string="Default economic activity", required=False, context={'active_test': False})
     signature = fields.Binary(string="Llave Criptográfica", )
     date_expiration_sign = fields.Datetime(string="Fecha de Vencimiento",)
@@ -201,7 +202,7 @@ class CompanyElectronic(models.Model):
                 for activity in economic_activities:
                     activity.active = True
 
-                self.name = json_response["name"]
+                self.legal_name = json_response["name"]
             else:
                 alert = {
                     'title': json_response["status"],

--- a/cr_electronic_invoice/views/res_company_views.xml
+++ b/cr_electronic_invoice/views/res_company_views.xml
@@ -18,6 +18,7 @@
 
                 <field name="website" position="before">
                     <field name="commercial_name"/>
+                    <field name="legal_name"/>
                     <field name="activity_id"  domain="[('active', '=', True)]" options='{"no_open": True, "no_create": True}' />
                     <button name="action_get_economic_activities" type="object" string="Consultar Actividad Economica en Hacienda" colspan="2" /> 
                 </field>


### PR DESCRIPTION
Description of the issue this PR addresses: 
Fixing the issue #246
* Se agrega el campo “legal_name” en res_company.py
* Se agrega el campo “legal_name” en la vista: res_comapany_views.xml
* Se modifica el metodo gen_xml_v43 para que asigne el campo legal_name: api_facturae.py

Current behavior before PR:
* Cuando se crea una segunda compañia (Compañía B) que utiliza la misma cédula que una compañía existente (Compañía A) y se consulta la actividad económica se genera un error, debido a que el método de consultar actividad económica asigna el nombre obtenido al nombre de la compañía

Desired behavior after PR is merged:
El nombre de la compañía debe ser único
* Compañía A
* Compañía B

Se asigna el nombre de la compania, cuando se hace la consulta de la actividad economica, al campo legal_name con lo cual Odoo permite crear otras compañías. 
