### PR TITLE
FIX obtener_nombre for http and https

### DIFF
--- a/l10n_cr_hacienda_info_query/static/src/js/actualizar_pos.js
+++ b/l10n_cr_hacienda_info_query/static/src/js/actualizar_pos.js
@@ -23,10 +23,8 @@ function httpGet(theUrl)
 }
 
 function obtener_nombre(vat) {
-        document.getElementsByName("vat")[0].value = vat
-        var host = window.location.host
-        var end_point = "http://" + host + "/cedula/" + vat
-        httpGet(end_point)
+        var end_point = window.location.origin + '/cedula/' + vat;
+        httpGet(end_point);
         }
 
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
En POS si se usa HTTPS al crear el cliente no jala el nombre

Desired behavior after PR is merged:
Resuelve obtener_nombre para HTTP o HTTPS