### PR TITLE
fix to allow multicompany environments to confirm provider invoices

### DIFF
--- a/cr_electronic_invoice/models/account_invoice.py
+++ b/cr_electronic_invoice/models/account_invoice.py
@@ -499,14 +499,15 @@ class AccountInvoiceElectronic(models.Model):
         account = False
         analytic_account = False
         product = False
-        load_lines = bool(self.env['ir.config_parameter'].sudo().get_param('load_lines'))
 
         purchase_journal = self.env['account.journal'].search([('type', '=', 'purchase')], limit=1)
         default_account_id = purchase_journal.expense_account_id.id
         if default_account_id:
             account = self.env['account.account'].search([('id', '=', default_account_id)], limit=1)
+            load_lines = purchase_journal.load_lines
         else:
             default_account_id = self.env['ir.config_parameter'].sudo().get_param('expense_account_id')
+            load_lines = bool(self.env['ir.config_parameter'].sudo().get_param('load_lines'))
             if default_account_id:
                 account = self.env['account.account'].search([('id', '=', default_account_id)], limit=1)
 

--- a/cr_electronic_invoice/models/account_invoice.py
+++ b/cr_electronic_invoice/models/account_invoice.py
@@ -501,17 +501,30 @@ class AccountInvoiceElectronic(models.Model):
         product = False
         load_lines = bool(self.env['ir.config_parameter'].sudo().get_param('load_lines'))
 
-        default_account_id = self.env['ir.config_parameter'].sudo().get_param('expense_account_id')
+        purchase_journal = self.env['account.journal'].search([('type', '=', 'purchase')], limit=1)
+        default_account_id = purchase_journal.expense_account_id.id
         if default_account_id:
             account = self.env['account.account'].search([('id', '=', default_account_id)], limit=1)
+        else:
+            default_account_id = self.env['ir.config_parameter'].sudo().get_param('expense_account_id')
+            if default_account_id:
+                account = self.env['account.account'].search([('id', '=', default_account_id)], limit=1)
 
-        analytic_account_id = self.env['ir.config_parameter'].sudo().get_param('expense_analytic_account_id')
+        analytic_account_id = purchase_journal.expense_analytic_account_id.id
         if analytic_account_id:
             analytic_account = self.env['account.analytic.account'].search([('id', '=', analytic_account_id)], limit=1)
+        else:
+            analytic_account_id = self.env['ir.config_parameter'].sudo().get_param('expense_analytic_account_id')
+            if analytic_account_id:
+                analytic_account = self.env['account.analytic.account'].search([('id', '=', analytic_account_id)], limit=1)
 
-        product_id = self.env['ir.config_parameter'].sudo().get_param('expense_product_id')
+        product_id = purchase_journal.expense_product_id.id
         if product_id:
             product = self.env['product.product'].search([('id', '=', product_id)], limit=1)
+        else:
+            product_id = self.env['ir.config_parameter'].sudo().get_param('expense_product_id')
+            if product_id:
+                product = self.env['product.product'].search([('id', '=', product_id)], limit=1)
 
         api_facturae.load_xml_data(self, load_lines, account, product, analytic_account)
 

--- a/cr_electronic_invoice/models/account_journal.py
+++ b/cr_electronic_invoice/models/account_journal.py
@@ -27,4 +27,22 @@ class AccountJournalInherit(models.Model):
     ND_sequence_id = fields.Many2one("ir.sequence",
                                      string="Secuencia de Notas de Débito Electrónicas",
                                      required=False)
+    expense_product_id = fields.Many2one(
+        'product.product',
+        string=_("Default product for expenses when loading data from XML"),
+        help=_("The default product used when loading Costa Rican digital invoice"))
 
+    expense_account_id = fields.Many2one(
+        'account.account',
+        string=_("Default Expense Account when loading data from XML"),
+        help=_("The expense account used when loading Costa Rican digital invoice"))
+
+    expense_analytic_account_id = fields.Many2one(
+        'account.analytic.account',
+        string=_("Default Analytic Account for expenses when loading data from XML"),
+        help=_("The analytic account used when loading Costa Rican digital invoice"))
+
+    load_lines = fields.Boolean(
+        string=_('Indicates if invoice lines should be load when loading a Costa Rican Digital Invoice'),
+        default=True
+    )

--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -1036,7 +1036,8 @@ def load_xml_data(invoice, load_lines, account_id, product_id=False, analytic_ac
     tipo_emisor = invoice_xml.xpath("inv:Emisor/inv:Identificacion/inv:Tipo", namespaces=namespaces)[0].text
     nombre_emisor = invoice_xml.xpath("inv:Emisor/inv:Nombre", namespaces=namespaces)[0].text
     pais_emisor = invoice.env['res.country'].search([('name', '=', 'Costa Rica')], limit=1).id
-    telefono_emisor = invoice_xml.xpath("inv:Emisor/inv:Telefono/inv:NumTelefono", namespaces=namespaces)[0].text    otrassenas_emisor = invoice_xml.xpath("inv:Emisor/inv:Ubicacion/inv:OtrasSenas", namespaces=namespaces)[0].text
+    telefono_emisor = invoice_xml.xpath("inv:Emisor/inv:Telefono/inv:NumTelefono", namespaces=namespaces)[0].text
+    otrassenas_emisor = invoice_xml.xpath("inv:Emisor/inv:Ubicacion/inv:OtrasSenas", namespaces=namespaces)[0].text
     correo_emisor = invoice_xml.xpath("inv:Emisor/inv:CorreoElectronico", namespaces=namespaces)[0].text
 
     receptor_node = invoice_xml.xpath("inv:Receptor/inv:Identificacion/inv:Numero", namespaces=namespaces)

--- a/cr_electronic_invoice/views/account_journal_views.xml
+++ b/cr_electronic_invoice/views/account_journal_views.xml
@@ -24,6 +24,17 @@
                             </group>
                         </group>
                     </page>
+                    <page string="Facturación Electrónica" attrs="{'invisible':[('type','!=','purchase')]}">
+                        <group cols="2">
+                            <group cols="2">
+                                <field name="expense_product_id" string="Default product for expenses when importing electronic invoice" />
+                                <field name="expense_account_id" string="Default account for expenses when importing electronic invoice" />
+                                <field name="expense_analytic_account_id" string="Default analytic account for expenses when importing electronic invoice"/>
+                                <div class="o_form_label" >Load invoice lines?</div>
+                                <field name="load_lines" />
+                            </group>
+                        </group>
+                    </page>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fix a new line problem on account_invoice.py
Environments with multi company could import invoices
Current behavior before PR:
Environment with multi company couldn´t import invoices
Desired behavior after PR is merged:
Environments with multi company could import invoices