### PR TITLE
[12.0] POS order loses consecutive and electronic number

### DIFF
--- a/cr_electronic_invoice_pos/static/src/js/models.js
+++ b/cr_electronic_invoice_pos/static/src/js/models.js
@@ -66,23 +66,24 @@ odoo.define('cr_electronic_invoice_pos.models', function (require) {
                 model: 'ir.sequence',
                 fields: [],
                 ids:    function(self){ return [self.config.FE_sequence_id[0],self.config.TE_sequence_id[0]]; },
-                loaded: function(self, sequence){ self.FE_sequence = sequence[0];self.TE_sequence = sequence[1]; },
+                loaded: function(self, sequence){ self.FE_sequence = sequence[0]; self.TE_sequence = sequence[1]; },
             });
             //debugger;
             return PosModelParent.load_server_data.apply(this, arguments);
         },
         push_order: function(order, opts) {
             //debugger;
-            if (order !== undefined) {
+            var self = this;
+            if (order) {
                 if (order.get('client') && order.get('client').vat) {
-                    order.set({'sequence': this.FE_sequence.number_next_actual});
-                    order.set({'number_electronic': _sequence_next(this.FE_sequence)});
-                    order.set({'tipo_documento': 'FE'});
+                    order.set_sequence(this.FE_sequence.number_next_actual);
+                    order.set_number_electronic(_sequence_next(this.FE_sequence));
+                    order.set_tipo_documento('FE');
 
                 } else {
-                    order.set({'sequence': this.TE_sequence.number_next_actual});
-                    order.set({'number_electronic': _sequence_next(this.TE_sequence)});
-                    order.set({'tipo_documento': 'TE'});
+                    order.set_sequence(this.TE_sequence.number_next_actual);
+                    order.set_number_electronic(_sequence_next(this.TE_sequence));
+                    order.set_tipo_documento('TE');
                 }
             };
             //debugger;
@@ -93,22 +94,40 @@ odoo.define('cr_electronic_invoice_pos.models', function (require) {
 
     var OrderParent = models.Order.prototype;
     models.Order = models.Order.extend({
-        export_for_printing: function(attributes){
+        export_for_printing: function(){
             var order = OrderParent.export_for_printing.apply(this, arguments);
-            order['number_electronic'] = this.get('number_electronic');
-            order['sequence'] = this.get('sequence');
-            order['tipo_documento'] = this.get('tipo_documento');
+            order.number_electronic = this.get_number_electronic();
+            order.sequence = this.get_sequence();
+            order.tipo_documento = this.get_tipo_documento();
             //debugger;
             return order;
         },
         export_as_JSON: function() {
             var order = OrderParent.export_as_JSON.apply(this, arguments);
-            order['number_electronic'] = this.get('number_electronic');
-            order['sequence'] = this.get('sequence');
-            order['tipo_documento'] = this.get('tipo_documento');
+            order.number_electronic = this.get_number_electronic();
+            order.sequence = this.get_sequence();
+            order.tipo_documento = this.get_tipo_documento();
             //debugger;
             return order;
-        }
+        },
+        set_number_electronic: function (number_electronic) {
+            this.number_electronic = number_electronic;
+        },
+        get_number_electronic: function () {
+            return this.number_electronic;
+        },
+        set_sequence: function (sequence) {
+            this.sequence = sequence;
+        },
+        get_sequence: function () {
+            return this.sequence;
+        },
+        set_tipo_documento: function (tipo_documento) {
+            this.tipo_documento = tipo_documento;
+        },
+        get_tipo_documento: function () {
+            return this.tipo_documento;
+        },
     });
 
     //models.load_fields('res.company', ['street', 'city', 'state_id', 'zip']);

--- a/cr_electronic_invoice_pos/static/src/xml/pos.xml
+++ b/cr_electronic_invoice_pos/static/src/xml/pos.xml
@@ -2,15 +2,15 @@
 <templates id="template" xml:space="preserve">
     <t t-extend="PosTicket">
         <t t-jquery="div.pos-center-align:first" t-operation="after">
-          <t t-if="order.attributes.number_electronic">
+          <t t-if="order.number_electronic">
             <div class="pos-center-align">
                   Clave: <br/>
-                  <t t-esc="order.attributes.number_electronic.substring(0,25)"/><br/>
-                  <t t-esc="order.attributes.number_electronic.substring(25,50)"/>
+                  <t t-esc="order.number_electronic.substring(0,25)"/><br/>
+                  <t t-esc="order.number_electronic.substring(25,50)"/>
             </div>
             <div class="pos-center-align">
                   Consecutivo: <br/>
-                  <t t-esc="order.attributes.number_electronic.substring(21,41)"/>
+                  <t t-esc="order.number_electronic.substring(21,41)"/>
             </div>
           </t>
         </t>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Cuando POS pierde conexión a internet puede duplicarse el consecutivo y clave de Hacienda al imprimir y el segundo pedido con el mismo consecutivo y clave queda sin estos datos en el backend.

Desired behavior after PR is merged:
Se guardan los datos de consecutivo y clave numérica al validar el pedido. Con esto el consecutivo y clave numérica no se pierden y no se duplican.