### PR TITLE
[FIX] Overwriting issue date - Odoo 14.0

### DIFF
--- a/cr_electronic_invoice/models/account_move.py
+++ b/cr_electronic_invoice/models/account_move.py
@@ -945,7 +945,7 @@ class AccountInvoiceElectronic(models.Model):
 
                 if not inv.sequence or not inv.sequence.isdigit():  # or (len(inv.number) == 10):
                     inv.state_tributacion = 'na'
-                    _logger.info('E-INV CR - Ignored invoice:%s', inv.number)
+                    _logger.info('E-INV CR - Ignored invoice:%s', inv.name)
                     continue
 
                 _logger.debug('generate_and_send_invoices - Invoice %s / %s  -  number:%s',

--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -880,7 +880,8 @@ def consulta_documentos(self, inv, env, token_m_h, date_cr, xml_firmado):
         # Se actualiza el estado con el que devuelve Hacienda
         last_state = inv.state_tributacion
         inv.state_tributacion = estado_m_h
-        inv.date_issuance = date_cr
+        if date_cr:
+            inv.date_issuance = date_cr
         if xml_firmado:
             inv.fname_xml_comprobante = inv.tipo_documento + inv.number_electronic + '.xml'
 

--- a/res_currency_cr_adapter/models/res_currency.py
+++ b/res_currency_cr_adapter/models/res_currency.py
@@ -23,8 +23,8 @@ class ResCurrency(models.Model):
     def action_create_missing_exchange_rates(self):
         currency_rate_obj = self.env['res.currency.rate']
         # A day is added to fix the loss of the current day
-        today = datetime.date.today()
-        last_day = today + datetime.timedelta(days=1)
+        today = datetime.today().date()
+        last_day = today + timedelta(days=1)
 
         first_day = currency_rate_obj.search([
             ('company_id', '=', self.env.user.company_id.id),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When the invoice is consulted manually, the issue date is overwritten

Current behavior before PR:
Clicking the "consult document" button causes the document's issue date to be deleted

Desired behavior after PR is merged:
When the document is consulted manually through the "consult document" button, the information on the date of issue of the document is not deleted