### PR TITLE
 [FIX] Clone POS order lines to NC- Odoo 15.0

### DIFF
--- a/cr_electronic_invoice_pos/models/electronic_invoice.py
+++ b/cr_electronic_invoice_pos/models/electronic_invoice.py
@@ -245,6 +245,14 @@ class PosOrder(models.Model):
                 'amount_total': -order.amount_total,
                 'amount_paid': 0,
             })
+            for line in order.lines:
+                clone_line = line.copy({
+                    'name': line.name + _(' REFUND'),
+                    'order_id': clone.id,
+                    'qty': -line.qty,
+                    'price_subtotal': -line.price_subtotal,
+                    'price_subtotal_incl': -line.price_subtotal_incl,
+                })
 
             pos_order += clone
         return {


### PR DESCRIPTION
NC-POS backend deletes order lines

Description of the issue/feature this PR addresses:

Current behavior before PR:
NC-POS backend deletes order lines
Desired behavior after PR is merged:
NC must clone the order lines