### PR TITLE
[12.0] Nombre automático POS con cédula sin usuario yo contribuyo

### DIFF
--- a/cr_electronic_invoice/models/account_invoice.py
+++ b/cr_electronic_invoice/models/account_invoice.py
@@ -1496,7 +1496,7 @@ class AccountInvoiceElectronic(models.Model):
                     sequence = inv.company_id.FEC_sequence_id.next_by_id()
 
             if not inv.tipo_documento or (inv.type in ('in_invoice', 'in_refund') and inv.tipo_documento in (
-            "CCE", "CPCE", "RCE", "FE", "NC")):
+            "CCE", "CPCE", "RCE", "FE", "NC", "ND")):
                 super(AccountInvoiceElectronic, inv).action_invoice_open()
                 continue
 

--- a/l10n_cr_hacienda_info_query/controllers/routes_controller.py
+++ b/l10n_cr_hacienda_info_query/controllers/routes_controller.py
@@ -22,7 +22,8 @@ class actualizar_pos_api(http.Controller):
         url_base_yo_contribuyo = company_id.url_base_yo_contribuyo
         usuario_yo_contribuyo = company_id.usuario_yo_contribuyo
         token_yo_contribuyo = company_id.token_yo_contribuyo
-        _logger.info(url_base_yo_contribuyo + " " + usuario_yo_contribuyo + " " + token_yo_contribuyo)
+        all_emails_yo_contribuyo = ""
+        # logger.info(url_base_yo_contribuyo + " " + usuario_yo_contribuyo + " " + token_yo_contribuyo)
         if url_base_yo_contribuyo and usuario_yo_contribuyo and token_yo_contribuyo:
             url_base_yo_contribuyo = url_base_yo_contribuyo.strip()
 
@@ -88,7 +89,7 @@ class actualizar_pos_api(http.Controller):
                                     identification_id = id_type.search([('code', '=', '05')], limit=1).id
                     if contenido.get('nombre') != None:
                         name = contenido.get('nombre')
-                        retorno = {"nombre":str(name),"identification_id":str(identification_id),"email": str(all_emails_yo_contribuyo)}
+                        retorno = {"nombre":str(name),"identification_id":str(identification_id),"email":str(all_emails_yo_contribuyo)}
                         return '%s' % str(retorno).replace("'","\"")
 
             #Si la petición arroja error se almacena en el campo ultima_respuesta de res_company. Nota: se usa execute ya que el metodo por objeto no funciono


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Si no se ingresa usuario y token de yo contribuyo no jala el nombre

Current behavior before PR:
No jala el nombre del contribuyente

Desired behavior after PR is merged:
Jalar el nombre del contribuyente (sin el correo) sin tener usuario y token de yo contribuyo