### PR TITLE
Ignora barrio al validar, fix crear partner al importar factura

### DIFF
--- a/cr_electronic_invoice/models/account_journal.py
+++ b/cr_electronic_invoice/models/account_journal.py
@@ -81,6 +81,9 @@ class AccountJournalInherit(models.Model):
                 break
         if not invoice:
             invoice = self.env['account.move'].create({})
+        p_method = self.env['payment.methods'].search([('sequence', '=', '99')], limit=1)
+        if p_method:
+            invoice.payment_methods_id = p_method.id
         invoice.fname_xml_supplier_approval = attachment.name
         invoice.xml_supplier_approval = attachment.datas
         return invoice

--- a/cr_electronic_invoice/models/account_move.py
+++ b/cr_electronic_invoice/models/account_move.py
@@ -1446,7 +1446,7 @@ class AccountInvoiceElectronic(models.Model):
                 raise UserError(_('Select the type of issuer identification in the company profile'))
             if not inv.company_id.vat:
                 raise UserError(_('Please configure the identification in the company profile'))
-            if not inv.company_id.state_id or not inv.company_id.county_id or not inv.company_id.district_id or not inv.company_id.neighborhood_id or not inv.company_id.street:
+            if not inv.company_id.state_id or not inv.company_id.county_id or not inv.company_id.district_id or not inv.company_id.street:
                 raise UserError(_('Please complete the address information in the company profile'))
 
             if inv.partner_id and inv.partner_id.vat:

--- a/cr_electronic_invoice/models/api_facturae.py
+++ b/cr_electronic_invoice/models/api_facturae.py
@@ -1071,7 +1071,7 @@ def load_xml_data(invoice, load_lines, account_id, product_id=False, analytic_ac
                                                          'phone': telefono_emisor,
                                                          'email': correo_emisor,
                                                          'street': otrassenas_emisor,
-                                                         'supplier': 'True'})
+                                                         'supplier_rank': 1})
         if new_partner:
             invoice.partner_id = new_partner
         else:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Facturas no se pueden validar cuando el barrio no está establecido en mi compañía
Arreglar error al momento de crear contacto cuando se importa una factura de un proveedor, 

Current behavior before PR:
Al validar una factura se presenta un error de que se debe completar los datos de dirección de mi compañía, se está validando
el campo barrio aunque este no es requerido por hacienda.

Al intentar importar una factura de proveedor (de un proveedor que no existe) falla la creación del mismo debido a que el campo supplier ya no existe.

Desired behavior after PR is merged:

Ignora barrio al validar una factura (debido a que no es requerido por hacienda) y permite validar la factura

Se crea el proveedor correctamente al importar los datos del XML.
